### PR TITLE
Rename S3 bucket to 'bucket-time-bucket'

### DIFF
--- a/pulumi-programs/bucket-time/index.ts
+++ b/pulumi-programs/bucket-time/index.ts
@@ -3,7 +3,7 @@ import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 
 // Create an AWS resource (S3 Bucket)
-const bucket = new aws.s3.Bucket("my-bucket");
+const bucket = new aws.s3.Bucket("bucket-time-bucket");
 
 // Export the name of the bucket
 export const bucketName = bucket.id;


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-service/issues/30412 where the name "my-bucket" is very common, even with a random prefix, resulting in the bucket name already being taken.

Change to a slightly less common name.